### PR TITLE
Migration support

### DIFF
--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -37,21 +37,6 @@ class EnumField(models.Field):
 
         raise TypeError("Lookup type %r not supported." % lookup_type)
 
-    def south_field_triple(self):
-        from south.modelsinspector import introspector, NOT_PROVIDED
-        args, kwargs = introspector(self)
-
-        # repr(Item) is not only invalid as an lookup value, it actually causes
-        # South to generate invalid Python
-        if self.default != NOT_PROVIDED:
-            kwargs['default'] = None
-
-            # Cannot set a real default if the "default" kwarg is a callable.
-            if not callable(self.default):
-                kwargs['default'] = self.default and self.default.value
-
-        return ('django.db.models.fields.IntegerField', args, kwargs)
-
     def value_to_string(self, obj):
         item = self._get_val_from_obj(obj)
 

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.test_settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            import django
+        except ImportError:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            )
+        raise
+    execute_from_command_line(sys.argv)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,5 @@
+import random
+
 from django_enumfield import EnumField
 
 from django.db import models
@@ -8,3 +10,11 @@ from .enums import TestModelEnum
 class TestModel(models.Model):
     test_field = EnumField(TestModelEnum, default=TestModelEnum.A)
     test_field_no_default = EnumField(TestModelEnum)
+
+
+def random_default():
+    return random.choice(TestModelEnum)
+
+
+class TestModelRandomDefault(models.Model):
+    test_field = EnumField(TestModelEnum, default=random_default)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,3 +19,6 @@ TEMPLATES = [
         },
     },
 ]
+SILENCED_SYSTEM_CHECKS = [
+    '1_7.W001',
+]

--- a/tests/tests_migrations.py
+++ b/tests/tests_migrations.py
@@ -42,14 +42,29 @@ class MigrationTests(DjangoTestCase):
 
         self.assertEqual(failed, expect_failure)
 
+    def assertMigrationExists(self, migration_number, exists=True):
+        migration_dir = os.path.join(self.tmp, 'tests', 'migrations')
+
+        migration_numbers = [
+            x.split('_')[0] for x in os.listdir(migration_dir)
+        ]
+
+        self.assertEqual(migration_number in migration_numbers, exists)
+
     def test_make_migrations(self):
         self.run_command('makemigrations tests')
+        self.assertMigrationExists('0001')
 
     def test_migrate(self):
         self.run_command('makemigrations tests')
+        self.assertMigrationExists('0001')
         self.run_command('migrate')
 
     def test_stable_migrations(self):
         self.run_command('makemigrations tests')
+        self.assertMigrationExists('0001')
+
         self.run_command('migrate')
+
         self.run_command('makemigrations tests --exit', expect_failure=True)
+        self.assertMigrationExists('0002', exists=False)

--- a/tests/tests_migrations.py
+++ b/tests/tests_migrations.py
@@ -1,0 +1,55 @@
+import os
+import shutil
+import tempfile
+import subprocess
+
+from django.test import TestCase as DjangoTestCase
+
+
+class MigrationTests(DjangoTestCase):
+    """
+    In order to test migrations in the test project, via the public migrations
+    interface (the management commands), we copy the test directory into a
+    temporary location, and run management commands against that project.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        src = os.path.dirname(__file__)
+
+        shutil.copytree(
+            src,
+            os.path.join(self.tmp, os.path.basename(src)),
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def run_command(self, command, expect_failure=False):
+        failed = False
+        try:
+            return subprocess.check_output(
+                'python %s/tests/manage.py %s' % (self.tmp, command),
+                shell=True,
+            )
+        except subprocess.CalledProcessError as e:
+            if expect_failure:
+                self.assertNotEqual(e.returncode, 0)
+                failed = True
+            else:
+                print(e.output)
+                self.assertEqual(e.returncode, 0)
+
+        self.assertEqual(failed, expect_failure)
+
+    def test_make_migrations(self):
+        self.run_command('makemigrations tests')
+
+    def test_migrate(self):
+        self.run_command('makemigrations tests')
+        self.run_command('migrate')
+
+    def test_stable_migrations(self):
+        self.run_command('makemigrations tests')
+        self.run_command('migrate')
+        self.run_command('makemigrations tests --exit', expect_failure=True)


### PR DESCRIPTION
This adds support for Django migrations, and drops support for South migrations. It includes integration tests for migrations.

Definitely open to comments on the approach to testing this. It's not ideal, but it also saves writing against the private API of Django's migration internals.