### PR TITLE
Django 1.9

### DIFF
--- a/django_enumfield/context_processors.py
+++ b/django_enumfield/context_processors.py
@@ -1,7 +1,7 @@
 import inspect
 
 from django.conf import settings
-from django.utils.functional import memoize
+from django.utils.lru_cache import lru_cache
 
 from .enum import Enum
 from .utils import TemplateErrorDict
@@ -9,6 +9,7 @@ from .utils import TemplateErrorDict
 def enumfield_context(request):
     return {'enums': get_enums()}
 
+@lru_cache()
 def get_enums():
     result = TemplateErrorDict("Unknown app name %s")
 
@@ -30,5 +31,3 @@ def get_enums():
             )[x.name] = x
 
     return result
-
-get_enums = memoize(get_enums, {}, 0)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -22,3 +22,4 @@ TEMPLATES = [
 SILENCED_SYSTEM_CHECKS = [
     '1_7.W001',
 ]
+ROOT_URLCONF = 'tests.urls'

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,1 @@
+urlpatterns = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django18
+envlist = py27-django{18,19}
 
 [testenv]
 commands = coverage run --source ./django_enumfield runtests.py
@@ -7,3 +7,4 @@ deps =
     pytest-django
     pytest-cov
     django18: django==1.8
+    django19: django==1.9


### PR DESCRIPTION
Quick one, this fixes `django-enumfield` on Django 1.9, and includes it in the test suite.