### PR TITLE
Improve coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/_build
 .coverage
 .tox/
 *.egg-info/
+htmlcov/

--- a/django_enumfield/context_processors.py
+++ b/django_enumfield/context_processors.py
@@ -1,7 +1,7 @@
 import inspect
 
 from django.conf import settings
-from django.utils.functional import memoize
+from django.utils.lru_cache import lru_cache
 
 from .enum import Enum
 from .utils import TemplateErrorDict
@@ -9,6 +9,7 @@ from .utils import TemplateErrorDict
 def enumfield_context(request):
     return {'enums': get_enums()}
 
+@lru_cache()
 def get_enums():
     result = TemplateErrorDict("Unknown app name %s")
 
@@ -30,5 +31,3 @@ def get_enums():
             )[x.name] = x
 
     return result
-
-get_enums = memoize(get_enums, {}, 0)

--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -29,6 +29,12 @@ class Enum(list):
         self.append(item)
 
     def from_value(self, value):
+        if not isinstance(value, int):
+            # Allow values that convert to int, as we might be deserialising an
+            # int value. Raises ValueError and falls through to_python
+            # accordingly if this is not actually an int.
+            value = int(value)
+
         try:
             return {x.value: x for x in self}[value]
         except KeyError:

--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -16,17 +16,17 @@ class EnumField(models.Field):
     def to_python(self, value):
         return self.enum.to_python(value)
 
-    def get_db_prep_save(self, value, connection=None):
+    def get_prep_value(self, value):
         if value is None:
             return value
 
         return self.to_python(value).value
 
-    def get_db_prep_lookup(self, lookup_type, value, connection=None, prepared=False):
+    def get_prep_lookup(self, lookup_type, value):
         def prepare(value):
             x = self.to_python(value)
 
-            return self.get_db_prep_save(x, connection=connection)
+            return self.get_prep_value(x)
 
         if lookup_type in ('exact', 'lt', 'lte', 'gt', 'gte'):
             return [prepare(value)]

--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -29,11 +29,11 @@ class EnumField(models.Field):
             return self.get_prep_value(x)
 
         if lookup_type in ('exact', 'lt', 'lte', 'gt', 'gte'):
-            return [prepare(value)]
+            return prepare(value)
         elif lookup_type == 'in':
             return [prepare(v) for v in value]
         elif lookup_type == 'isnull':
-            return []
+            return value
 
         raise TypeError("Lookup type %r not supported." % lookup_type)
 

--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -38,8 +38,7 @@ class EnumField(models.Field):
         raise TypeError("Lookup type %r not supported." % lookup_type)
 
     def value_to_string(self, obj):
-        item = self._get_val_from_obj(obj)
-
+        item = self.value_from_object(obj)
         return str(item.value)
 
     def clone(self):

--- a/runtests.py
+++ b/runtests.py
@@ -11,5 +11,5 @@ if __name__ == '__main__':
     django.setup()
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
-    failures = test_runner.run_tests(['tests'])
+    failures = test_runner.run_tests(sys.argv[1:])
     sys.exit(bool(failures))

--- a/tests/app/__init__.py
+++ b/tests/app/__init__.py
@@ -1,0 +1,4 @@
+"""
+This app has no enums module, and is used to exercise a particular check in the
+enum discovery logic for the template context processor
+"""

--- a/tests/models.py
+++ b/tests/models.py
@@ -12,6 +12,10 @@ class TestModel(models.Model):
     test_field_no_default = EnumField(TestModelEnum)
 
 
+class TestModelNull(models.Model):
+    test_field_null = EnumField(TestModelEnum, null=True)
+
+
 def random_default():
     return random.choice(TestModelEnum)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 SECRET_KEY = 'fake-key'
 INSTALLED_APPS = [
     'tests',
+    'tests.app',
 ]
 DATABASES = {
     'default': {

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -22,3 +22,4 @@ TEMPLATES = [
 SILENCED_SYSTEM_CHECKS = [
     '1_7.W001',
 ]
+ROOT_URLCONF = 'tests.urls'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -296,6 +296,10 @@ class FieldTests(DjangoTestCase):
 
         self.assertEqual(list(query), [m1])
 
+    def test_unsupported_lookup(self):
+        with self.assertRaises(TypeError):
+            TestModel.objects.filter(test_field__icontains=('blah',))
+
 
 class TemplateTests(DjangoTestCase):
     def test_renders_template(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -9,7 +9,7 @@ from django_enumfield import Enum, Item, get_enum_or_404
 from django_enumfield.utils import TemplateErrorException
 
 from .enums import TestModelEnum
-from .models import TestModel
+from .models import TestModel, TestModelNull
 
 
 class ItemTests(unittest.TestCase):
@@ -250,6 +250,51 @@ class FieldTests(DjangoTestCase):
             )),
             [m1],
         )
+
+    def test_null_field(self):
+        TestModelNull.objects.create(test_field_null=None)
+
+    def test_field_lookup(self):
+        TestModelNull.objects.create(test_field_null=None)
+        m2 = TestModelNull.objects.create(test_field_null=TestModelEnum.A)
+
+        query = TestModelNull.objects.filter(
+            test_field_null__in=(TestModelEnum.A, TestModelEnum.B),
+        )
+
+        self.assertEqual(list(query), [m2])
+
+    def test_field_lookup_in_slugs(self):
+        TestModelNull.objects.create(test_field_null=None)
+        m2 = TestModelNull.objects.create(test_field_null=TestModelEnum.A)
+
+        query = TestModelNull.objects.filter(test_field_null__in=('a', 'b'))
+
+        self.assertEqual(list(query), [m2])
+
+    def test_field_lookup_in_values(self):
+        TestModelNull.objects.create(test_field_null=None)
+        m2 = TestModelNull.objects.create(test_field_null=TestModelEnum.A)
+
+        query = TestModelNull.objects.filter(test_field_null__in=(10, 20))
+
+        self.assertEqual(list(query), [m2])
+
+    def test_field_lookup_in_non_existent_slug_fails(self):
+        with self.assertRaises(ValueError):
+            TestModel.objects.filter(test_field__in=('blah',))
+
+    def test_field_lookup_in_non_existent_value_fails(self):
+        with self.assertRaises(ValueError):
+            TestModel.objects.filter(test_field__in=(999,))
+
+    def test_isnull(self):
+        m1 = TestModelNull.objects.create(test_field_null=None)
+        TestModelNull.objects.create(test_field_null=TestModelEnum.A)
+
+        query = TestModelNull.objects.filter(test_field_null__isnull=True)
+
+        self.assertEqual(list(query), [m1])
 
 
 class TemplateTests(DjangoTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -282,7 +282,7 @@ class FieldTests(DjangoTestCase):
 
     def test_field_lookup_in_non_existent_slug_fails(self):
         with self.assertRaises(ValueError):
-            TestModel.objects.filter(test_field__in=('blah',))
+            TestModel.objects.filter(test_field__in=('not_a_slug',))
 
     def test_field_lookup_in_non_existent_value_fails(self):
         with self.assertRaises(ValueError):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,10 +1,12 @@
 import unittest
 
+from django.db import models
 from django.core import serializers
 from django.http import HttpRequest, Http404
 from django.test import TestCase as DjangoTestCase
 from django.template import RequestContext
 from django.template.loader import render_to_string
+from django.db.models.fields import NOT_PROVIDED
 
 from django_enumfield import Enum, Item, get_enum_or_404
 from django_enumfield.utils import TemplateErrorException
@@ -360,6 +362,22 @@ class MigrationUnitTests(DjangoTestCase):
             [],
             {'default': 10},
         )
+
+    def test_field_clone(self):
+        model = TestModel()
+        field = model._meta.get_field('test_field_no_default')
+        clone = field.clone()
+
+        self.assertTrue(isinstance(clone, models.IntegerField))
+        self.assertEqual(clone.default, NOT_PROVIDED)
+
+    def test_field_clone_with_default(self):
+        model = TestModel()
+        field = model._meta.get_field('test_field')
+        clone = field.clone()
+
+        self.assertTrue(isinstance(clone, models.IntegerField))
+        self.assertEqual(clone.default, 10)
 
 
 class SerialisationTests(DjangoTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -78,6 +78,20 @@ class EnumConstructionTests(unittest.TestCase):
         self.assertEqual(FooEnum.B.display, "Item B")
         self.assertEqual(FooEnum.from_value(10).slug, 'a')
 
+    def test_dynamic_enum_rejects_duplicate_value(self):
+        FooEnum = Enum('FooEnum')
+        FooEnum.add_item(Item(10, 'a', "Item A"))
+
+        with self.assertRaises(ValueError):
+            FooEnum.add_item(Item(10, 'b', "Item B"))
+
+    def test_dynamic_enum_rejects_duplicate_slug(self):
+        FooEnum = Enum('FooEnum')
+        FooEnum.add_item(Item(10, 'a', "Item A"))
+
+        with self.assertRaises(ValueError):
+            FooEnum.add_item(Item(20, 'a', "Item B"))
+
     def test_simple_registry_enum(self):
         FooEnum = Enum('FooEnum')
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -181,6 +181,12 @@ class EnumTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.enum.to_python('not_a_slug')
 
+    def test_repr(self):
+        self.assertEqual(
+            repr(self.enum),
+            "<FooEnum: [%r, %r]>" % (self.enum.A, self.enum.B),
+        )
+
 
 class FieldTests(DjangoTestCase):
     def assertCreated(self, num=1):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,6 @@
 import unittest
 
+from django.core import serializers
 from django.http import HttpRequest, Http404
 from django.test import TestCase as DjangoTestCase
 from django.template import RequestContext
@@ -358,4 +359,21 @@ class MigrationUnitTests(DjangoTestCase):
             'test_field',
             [],
             {'default': 10},
+        )
+
+
+class SerialisationTests(DjangoTestCase):
+    def test_serialisation(self):
+        m_in = TestModel.objects.create(test_field_no_default=TestModelEnum.B)
+
+        data = serializers.serialize('xml', TestModel.objects.all())
+        objects = serializers.deserialize('xml', data)
+
+        m_out = next(objects).object
+
+        self.assertEqual(m_in.pk, m_out.pk)
+        self.assertEqual(m_in.test_field, m_out.test_field)
+        self.assertEqual(
+            m_in.test_field_no_default,
+            m_out.test_field_no_default,
         )

--- a/tests/tests_migrations.py
+++ b/tests/tests_migrations.py
@@ -6,7 +6,7 @@ import subprocess
 from django.test import TestCase as DjangoTestCase
 
 
-class MigrationTests(DjangoTestCase):
+class MigrationIntegrationTests(DjangoTestCase):
     """
     In order to test migrations in the test project, via the public migrations
     interface (the management commands), we copy the test directory into a

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,1 @@
+urlpatterns = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django18
+envlist = py27-django{18,19}
 
 [testenv]
 commands = coverage run --source ./django_enumfield runtests.py
@@ -7,3 +7,4 @@ deps =
     pytest-django
     pytest-cov
     django18: django==1.8
+    django19: django==1.9

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,10 @@
 envlist = py27-django{18,19}
 
 [testenv]
-commands = coverage run --source ./django_enumfield runtests.py
+commands =
+    coverage erase
+    coverage run --source ./django_enumfield runtests.py
+    coverage report
 deps =
     pytest-django
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-django{18,19}
+envlist = py27-django{18,19}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{18,19}
+envlist = {py27,py34,py35}-django{18,19}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = {py27,py34,py35}-django{18,19}
 [testenv]
 commands =
     coverage erase
-    coverage run --source ./django_enumfield runtests.py
+    coverage run --branch --source ./django_enumfield runtests.py
     coverage report
 deps =
     pytest-django


### PR DESCRIPTION
This PR brings the codebase up to as near 100% coverage as is practical (there are a few list comprehensions that claim partial coverage, but this appears to be an oddity of Python's generators rather than a real lack of coverage).

As part of this, I encountered what looks like a regression:

```python
>>> FooModel.objects.filter(field__in=('not_a_slug',))
[]
```

Previously with django-enumfield, this would have resulted in a `TypeError` like so:

```python
>>> FooModel.objects.filter(field__in=('not_a_slug',))
<ValueError: 'not_a_slug' is not a valid slug or value for the enumeration>
```

To fix this, I've changed the field API implemented from the `get_db_prep*` methods to the `get_prep*` methods. The former are designed for implementing database backend specific changes, which we don't need, and the latter are designed for implementing type checks and data validation, which is what we want. This didn't change the behaviour.

I've also fixed deserialisation, because while the `value_to_string` method provided serialisation behaviour, the `to_python` method did not account for the inverse operation. Now, integers as strings will take precedence over slugs when looking up in an enum. This is a behaviour change.

Note: this PR includes the changes from #3, and all tests pass on Python 2.7 with Django 1.8 and 1.9.