### PR TITLE
Django 1.10 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.pyc
 docs/_build
-.coverage
+.coverage*
 .tox/
 *.egg-info/
 htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+test: clean
+	tox
+	coverage combine
+	coverage report
+	coverage html
+
+clean:
+	rm -f .coverage.*
+	rm -rf htmlcov
+	coverage erase
+
+.PHONY: test clean

--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -1,8 +1,14 @@
 import six
 
+import django
 from django.db import models
 
-class EnumField(six.with_metaclass(models.SubfieldBase, models.Field)):
+if django.VERSION < (1, 10):
+    metaclass = models.SubfieldBase
+else:
+    metaclass = type
+
+class EnumField(six.with_metaclass(metaclass, models.Field)):
     def __init__(self, enum, *args, **kwargs):
         self.enum = enum
 
@@ -15,6 +21,9 @@ class EnumField(six.with_metaclass(models.SubfieldBase, models.Field)):
 
     def to_python(self, value):
         return self.enum.to_python(value)
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def get_prep_value(self, value):
         if value is None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -301,8 +301,10 @@ class FieldTests(DjangoTestCase):
         self.assertEqual(list(query), [m1])
 
     def test_unsupported_lookup(self):
-        with self.assertRaises(TypeError):
-            TestModel.objects.filter(test_field__icontains=('blah',))
+        if django.VERSION < (1, 10):
+            # This feature is only supported pre-Django 1.10.
+            with self.assertRaises(TypeError):
+                TestModel.objects.filter(test_field__icontains=('blah',))
 
 
 class TemplateTests(DjangoTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,6 @@
 import unittest
 
+import django
 from django.db import models
 from django.core import serializers
 from django.http import HttpRequest, Http404
@@ -306,18 +307,22 @@ class FieldTests(DjangoTestCase):
 
 class TemplateTests(DjangoTestCase):
     def test_renders_template(self):
-        ctx = RequestContext(HttpRequest())
+        kwargs = {'request': HttpRequest()}
+        if django.VERSION < (1, 10):
+            kwargs = {'context_instance': RequestContext(HttpRequest())}
 
         self.assertEqual(
-            render_to_string('test.html', context_instance=ctx),
+            render_to_string('test.html', {}, **kwargs),
             "Item A, Item B\n",
         )
 
     def test_fails_loudly_for_invalid_app(self):
-        ctx = RequestContext(HttpRequest())
+        kwargs = {'request': HttpRequest()}
+        if django.VERSION < (1, 10):
+            kwargs = {'context_instance': RequestContext(HttpRequest())}
 
         with self.assertRaises(TemplateErrorException):
-            render_to_string('invalid.html', context_instance=ctx)
+            render_to_string('invalid.html', {}, **kwargs)
 
 
 class UtilsTests(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,6 @@ envlist = {py27,py34,py35}-django{18,19,110}
 commands =
     coverage erase
     coverage run --parallel-mode --branch --source ./django_enumfield runtests.py
-    coverage combine
-    coverage report
 deps =
     six
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-django{18,19}
+envlist = {py27,py34,py35}-django{18,19,110}
 
 [testenv]
 commands =
@@ -10,3 +10,4 @@ deps =
     six
     django18: django==1.8
     django19: django==1.9
+    django110: django==1.10b1

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,12 @@ envlist = {py27,py34,py35}-django{18,19,110}
 [testenv]
 commands =
     coverage erase
-    coverage run --branch --source ./django_enumfield runtests.py
+    coverage run --parallel-mode --branch --source ./django_enumfield runtests.py
+    coverage combine
     coverage report
 deps =
     six
+    coverage
     django18: django==1.8
     django19: django==1.9
     django110: django==1.10b1


### PR DESCRIPTION
 - Adds support for `to_python` instead of `SubfieldBase`.
 - Improves coverage setup so that we can track coverage across multiple test runs.

Note that previously, using 'incompatible' lookups (like `icontains`) on an `EnumField` would raise a `TypeError`. The way these are implemented has changed drastically, making it much more difficult (and likely not worth it) to change the default set of these lookups, so the test for the type error does not run on Django 1.10. I'm not sure if this is the best way of handling this, or if I'm misunderstanding the Django docs, but so far this looks like it should work fine for the majority of uses.