### PR TITLE
Better ValueError messages

### DIFF
--- a/django_enumfield/enum.py
+++ b/django_enumfield/enum.py
@@ -38,7 +38,7 @@ class Enum(list):
         try:
             return {x.value: x for x in self}[value]
         except KeyError:
-            raise ValueError("%r is not a valid value for the enum" % value)
+            raise ValueError("%r is not a valid value for enum %s" % (value, self.name))
 
     def from_slug(self, slug):
         if not isinstance(slug, basestring):
@@ -47,7 +47,7 @@ class Enum(list):
         try:
             return {x.slug.lower(): x for x in self}[slug.lower()]
         except KeyError:
-            raise ValueError("%r is not a valid slug for the enum" % slug)
+            raise ValueError("%r is not a valid slug for enum %s" % (slug, self.name))
 
     def get_choices(self):
         return [(x, x.display) for x in self]
@@ -69,4 +69,4 @@ class Enum(list):
         except (ValueError, TypeError):
             pass
 
-        raise ValueError("%r is not a valid slug or value for the enum" % value)
+        raise ValueError("%r is not a valid slug or value for enum %s" % (value, self.name))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -156,8 +156,14 @@ class EnumTests(unittest.TestCase):
     def test_from_value(self):
         self.assertEqual(self.enum.from_value(10).slug, 'a')
 
+        with self.assertRaises(ValueError):
+            self.enum.from_value('a')
+
     def test_from_slug(self):
         self.assertEqual(self.enum.from_slug('b').value, 20)
+
+        with self.assertRaises(ValueError):
+            self.enum.from_value(99)
 
     def test_get_choices(self):
         self.assertEqual(


### PR DESCRIPTION
Include the name of the enum in the `ValueErrors` when conversion from a slug or value fails. This makes debugging much easier as it's clear _which_ enum is throwing the error.

This is particularly needed when Django is converting from a database representation into an enum as part of creating the object representation for a model which has many `EnumField`s.