### PR TITLE
Better error when required field missing

### DIFF
--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -26,10 +26,12 @@ class EnumField(six.with_metaclass(metaclass, models.Field)):
         return self.to_python(value)
 
     def get_prep_value(self, value):
-        if value is None:
-            return value
+        python_value = self.to_python(value)
 
-        return self.to_python(value).value
+        if python_value is None:
+            return None
+
+        return python_value.value
 
     def get_prep_lookup(self, lookup_type, value):
         def prepare(value):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,7 @@ import unittest
 
 import django
 from django.db import models
+from django.db.utils import IntegrityError
 from django.core import serializers
 from django.http import HttpRequest, Http404
 from django.test import TestCase as DjangoTestCase
@@ -237,6 +238,17 @@ class FieldTests(DjangoTestCase):
         )
 
         self.assertCreated()
+
+    def test_model_instantiate_without_default(self):
+        TestModel(
+            test_field=TestModelEnum.A,
+        )
+
+    def test_model_creation_without_default(self):
+        with self.assertRaises(IntegrityError):
+            TestModel.objects.create(
+                test_field=TestModelEnum.A,
+            )
 
     def test_field_default(self):
         model = TestModel.objects.create(test_field_no_default=TestModelEnum.B)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -226,6 +226,18 @@ class FieldTests(DjangoTestCase):
 
         self.assertCreated()
 
+    def test_model_instantiate_using_defulat(self):
+        TestModel(
+            test_field_no_default=TestModelEnum.B,
+        )
+
+    def test_model_creation_using_defulat(self):
+        TestModel.objects.create(
+            test_field_no_default=TestModelEnum.B,
+        )
+
+        self.assertCreated()
+
     def test_field_default(self):
         model = TestModel.objects.create(test_field_no_default=TestModelEnum.B)
         self.assertEqual(model.test_field, TestModelEnum.A)


### PR DESCRIPTION
Currently if you fail to provide an enum value for an enumfield which doesn't have a default you get an `AttributeError` which isn't very useful as it doesn't tell you which field is missing.

Change the way that we prepare values for the database such that we instead rely on Django's handling of missing fields.

This means that we now also treat empty strings as nulls, which is probably fine.

If there's a better way to signal to Django that we're missing a required field then we should use that (I couldn't immediately spot one in the docs).