### PR TITLE
Better invalid slug message

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -176,8 +176,20 @@ class EnumTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.enum.from_slug(20)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             self.enum.from_slug('nope')
+
+        self.assertIn(
+            'nope',
+            str(cm.exception),
+            "Exception message should contain errenous slug",
+        )
+
+        self.assertIn(
+            self.enum.name,
+            str(cm.exception),
+            "Exception message should contain enum name",
+        )
 
     def test_get_choices(self):
         self.assertEqual(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -162,7 +162,17 @@ class EnumTests(unittest.TestCase):
             Item(20, 'b', "Item B"),
         )
 
+        LargeEnum = Enum(
+            'LargeEnum',
+            Item(10, 'item_a', "Item A"),
+            Item(20, 'item_b', "Item B"),
+            Item(30, 'item_c', "Item C"),
+            Item(40, 'item_d', "Item D"),
+            Item(50, 'item_e', "Item E"),
+        )
+
         self.enum = FooEnum
+        self.large_enum = LargeEnum
 
     def test_from_value(self):
         self.assertEqual(self.enum.from_value(10).slug, 'a')
@@ -186,7 +196,34 @@ class EnumTests(unittest.TestCase):
         )
 
         self.assertIn(
+            'a, b',
+            str(cm.exception),
+            "Exception message should contain valid slugs",
+        )
+
+        self.assertIn(
             self.enum.name,
+            str(cm.exception),
+            "Exception message should contain enum name",
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            self.large_enum.from_slug('item')
+
+        self.assertIn(
+            'item',
+            str(cm.exception),
+            "Exception message should contain errenous slug",
+        )
+
+        self.assertIn(
+            'item_e, item_d, item_c',
+            str(cm.exception),
+            "Exception message should contain valid slugs",
+        )
+
+        self.assertIn(
+            self.large_enum.name,
             str(cm.exception),
             "Exception message should contain enum name",
         )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -173,8 +173,11 @@ class EnumTests(unittest.TestCase):
     def test_from_slug(self):
         self.assertEqual(self.enum.from_slug('b').value, 20)
 
+        with self.assertRaises(TypeError):
+            self.enum.from_slug(20)
+
         with self.assertRaises(ValueError):
-            self.enum.from_value(99)
+            self.enum.from_slug('nope')
 
     def test_get_choices(self):
         self.assertEqual(


### PR DESCRIPTION
This provides much more detail in the error message and includes some valid slugs which the developer may have meant instead.