### PR TITLE
Support using the enumfield_context outside views

### DIFF
--- a/django_enumfield/context_processors.py
+++ b/django_enumfield/context_processors.py
@@ -6,7 +6,9 @@ from django.utils.lru_cache import lru_cache
 from .enum import Enum
 from .utils import TemplateErrorDict
 
-def enumfield_context(request):
+def enumfield_context(*args, **kwargs):
+    # We allow any arguments so that this function can be used outside views,
+    # for example by django-email-from-template.
     return {'enums': get_enums()}
 
 @lru_cache()


### PR DESCRIPTION
This is particularly useful if `django_enumfield` is used in conjunction with other django plugins, such as [django-email-from-template](https://chris-lamb.co.uk/projects/django-email-from-template).