### PR TITLE
Add mechanism to provide explicit class-based item slugs

### DIFF
--- a/django_enumfield/app_settings.py
+++ b/django_enumfield/app_settings.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+TEMPLATE = 'ENUMFIELD_%s'
+
+
+class NOT_PROVIDED:  # noqa
+    pass
+
+
+def setting(suffix, default=NOT_PROVIDED):
+    # Lazily get settings from ``django.conf.settings`` instance so that the
+    # @override_settings works.
+    @property
+    def fn(self):
+        key = TEMPLATE % suffix
+
+        try:
+            if default is NOT_PROVIDED:
+                return getattr(settings, key)
+        except AttributeError:
+            raise ImproperlyConfigured(
+                "Missing required setting: {}".format(key)
+            )
+
+        return getattr(settings, key, default)
+
+    return fn
+
+
+class AppSettings(object):
+    EXPLICIT_SLUGS = setting('EXPLICIT_SLUGS', default=False)
+
+
+app_settings = AppSettings()

--- a/django_enumfield/item.py
+++ b/django_enumfield/item.py
@@ -1,15 +1,25 @@
 import six
 import functools
 
+from .app_settings import app_settings
+
+
 class ItemMeta(type):
     def __new__(mcs, name, bases, attrs):
         cls = super(ItemMeta, mcs).__new__(mcs, name, bases, attrs)
 
         try:
-            item = cls(attrs['value'], name, attrs.get('display'))
+            value = attrs['value']
         except KeyError:
             pass
         else:
+            slug = name
+            if app_settings.EXPLICIT_SLUGS:
+                if 'slug' not in attrs:
+                    raise TypeError("%r class must have a slug attribute" % name)
+                slug = attrs['slug']
+
+            item = cls(value, slug, attrs.get('display'))
             cls.__enum__.add_item(item)
 
         return cls


### PR DESCRIPTION
This allows users to provide a slug value for their class-based item definitions, allowing class names to remain in PascalCase while also having a copy of the slug on the class that can be found by text searches.

For example:
``` python
BoxSizesEnum = Enum('BoxSizesEnum')

class LargeBox(Item):
    __enum__ = BoxSizesEnum
    value = 10
    slug = 'large_box'
    display = "Large box"

>>> print(BoxSizesEnum.LARGE_BOX)
<enum.Item: 10 large_box 'Large box'>
```