### PR TITLE
Drop old django support

### DIFF
--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -1,14 +1,7 @@
-import six
-
-from django import VERSION
 from django.db import models
 
-if VERSION < (1, 10):
-    metaclass = models.SubfieldBase
-else:
-    metaclass = type
 
-class EnumField(six.with_metaclass(metaclass, models.Field)):
+class EnumField(models.Field):
     def __init__(self, enum, *args, **kwargs):
         self.enum = enum
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=find_packages(),
 
     install_requires=(
-        'Django>=1.8',
+        'Django>=1.11',
         'six',
     ),
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -448,16 +448,14 @@ class FieldTests(DjangoTestCase):
 
 class TemplateTests(DjangoTestCase):
     def test_renders_template(self):
-        kwargs = {'request': HttpRequest()}
         self.assertEqual(
-            render_to_string('test.html', {}, **kwargs),
+            render_to_string('test.html', {}, request=HttpRequest()),
             "Item A, Item B\n",
         )
 
     def test_fails_loudly_for_invalid_app(self):
-        kwargs = {'request': HttpRequest()}
         with self.assertRaises(TemplateErrorException):
-            render_to_string('invalid.html', {}, **kwargs)
+            render_to_string('invalid.html', {}, request=HttpRequest())
 
 
 class UtilsTests(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -69,7 +69,7 @@ class ItemTests(unittest.TestCase):
         self.assertGreater(item2, item1)
         self.assertGreaterEqual(item2, item2_copy)
         self.assertLessEqual(item2, item2_copy)
-    
+
     def test_lazy_translation_in_display(self):
         item = Item(10, 'slug', _("Display"))
         self.assertEqual(item.display, "Display")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,12 +1,10 @@
 import unittest
 
-import django
 from django.db import models
 from django.db.utils import IntegrityError
 from django.core import serializers
 from django.http import HttpRequest, Http404
 from django.test import TestCase as DjangoTestCase, override_settings
-from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.db.models.fields import NOT_PROVIDED
 from django.utils.translation import gettext_lazy as _
@@ -447,19 +445,10 @@ class FieldTests(DjangoTestCase):
 
         self.assertEqual(list(query), [m1])
 
-    def test_unsupported_lookup(self):
-        if django.VERSION < (1, 10):
-            # This feature is only supported pre-Django 1.10.
-            with self.assertRaises(TypeError):
-                TestModel.objects.filter(test_field__icontains=('blah',))
-
 
 class TemplateTests(DjangoTestCase):
     def test_renders_template(self):
         kwargs = {'request': HttpRequest()}
-        if django.VERSION < (1, 10):
-            kwargs = {'context_instance': RequestContext(HttpRequest())}
-
         self.assertEqual(
             render_to_string('test.html', {}, **kwargs),
             "Item A, Item B\n",
@@ -467,9 +456,6 @@ class TemplateTests(DjangoTestCase):
 
     def test_fails_loudly_for_invalid_app(self):
         kwargs = {'request': HttpRequest()}
-        if django.VERSION < (1, 10):
-            kwargs = {'context_instance': RequestContext(HttpRequest())}
-
         with self.assertRaises(TemplateErrorException):
             render_to_string('invalid.html', {}, **kwargs)
 

--- a/tests/tests_migrations.py
+++ b/tests/tests_migrations.py
@@ -3,7 +3,6 @@ import shutil
 import tempfile
 import subprocess
 
-from django import VERSION
 from django.test import TestCase as DjangoTestCase
 
 
@@ -66,10 +65,7 @@ class MigrationIntegrationTests(DjangoTestCase):
         self.assertMigrationExists('0001')
 
         self.run_command('migrate')
-        
-        if VERSION < (1, 10):
-            self.run_command('makemigrations tests --exit', expect_failure=True)
-        else:
-            self.run_command('makemigrations tests --check', expect_failure=True)
+
+        self.run_command('makemigrations tests --check', expect_failure=True)
 
         self.assertMigrationExists('0002', exists=False)


### PR DESCRIPTION
This removes declared support for versions below 1.11 and removes related testing and functionality. This simplifies the definition of the `EnumField` class as well as a number of tests.