### PR TITLE
Drop Python 2.x testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django111,{py35,py36,py37}-django{111,20,21,22}
+envlist = {py35,py36,py37}-django{111,20,21,22}
 
 [testenv]
 commands =


### PR DESCRIPTION
This still tests Django 1.11 (which has [official support](https://www.djangoproject.com/download/#supported-versions) for about another 6 months) under Python 3 even though the `setup.py` doesn't claim support for that.