### PR TITLE
Fix import for migration deconstruction

### DIFF
--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -15,7 +15,7 @@ class EnumField(models.Field):
     def to_python(self, value):
         return self.enum.to_python(value)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection, *args, **kwargs):
         return self.to_python(value)
 
     def get_prep_value(self, value):

--- a/django_enumfield/fields.py
+++ b/django_enumfield/fields.py
@@ -68,4 +68,4 @@ class EnumField(models.Field):
         # We don't want to serialise this for migrations.
         del kwargs["choices"]
 
-        return name, "django.db.models.fields.IntegerField", args, kwargs
+        return name, "django.db.models.IntegerField", args, kwargs

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -475,7 +475,7 @@ class MigrationUnitTests(DjangoTestCase):
         model = model_class()
         name, path, args, kwargs = model._meta.get_field(field).deconstruct()
         self.assertEqual(name, field)
-        self.assertEqual(path, 'django.db.models.fields.IntegerField')
+        self.assertEqual(path, 'django.db.models.IntegerField')
         self.assertEqual(args, exp_args)
         self.assertEqual(kwargs, exp_kwargs)
 


### PR DESCRIPTION
This field moved its "canonical" location a long time ago (tests pass on supported versions of Django), and while the `.fields` location works, it results in unstable migrations when an EnumField is compared to previous migrations, for a compound field comprised of an EnumField and something else. A motivating use-case for this would be a `MoneyField` that combines a `DecimalField` and an `EnumField`.